### PR TITLE
Create a CI action to deploy Doxygen documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+# https://github.com/satu0king/Github-Documentation-With-Doxygen/blob/master/main.yml
+# This is a basic workflow to help you get started with Actions
+name: Doxygen Action
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    # branches: [ master ]  # Commenting for debug so that it always triggers
+  
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v4
+
+    # https://github.com/marketplace/actions/doxygen-action
+    - name: Doxygen Action
+      uses: mattnotmitt/doxygen-action@v1.9.5
+      with:
+        # Path to Doxyfile
+        doxyfile-path: "./Documentation/Doxyfile" # default is ./Doxyfile
+        # Working directory
+        working-directory: "." # default is .
+    
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        # Default Doxyfile build documentation to html directory. 
+        # Change the directory if changes in Doxyfile
+        publish_dir: ./documentation/html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@
 name: Doxygen Action
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# events but only for the main branch
 on:
   push:
-    # branches: [ master ]  # Commenting for debug so that it always triggers
+    branches: [ main ]
   
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
We relies on 2 GitHub actions:
- [`mattnotmitt/doxygen-action`](https://github.com/marketplace/actions/doxygen-action)
- [`peaceiris/actions-gh-pages`](https://github.com/peaceiris/actions-gh-pages): see in particular how to set up token and first deployment with token